### PR TITLE
Adding support for filesize and dimensions array

### DIFF
--- a/lib/parser/gif.rb
+++ b/lib/parser/gif.rb
@@ -7,7 +7,7 @@ class ImageSpec
 
       def self.attributes(stream)
         width, height = dimensions(stream)
-        {:width => width, :height => height, :content_type => CONTENT_TYPE}
+        {:width => width, :height => height, :content_type => CONTENT_TYPE, :dimensions => [width, height], :file_size => size(stream)}
       end
 
       def self.detected?(stream)
@@ -18,6 +18,10 @@ class ImageSpec
       def self.dimensions(stream)
         stream.seek(6)
         stream.read(4).unpack('SS')
+      end
+
+      def self.size(stream)
+        stream.size
       end
 
     end

--- a/lib/parser/jpeg.rb
+++ b/lib/parser/jpeg.rb
@@ -9,7 +9,7 @@ class ImageSpec
 
       def self.attributes(stream)
         width, height = dimensions(stream)
-        {:width => width, :height => height, :content_type => CONTENT_TYPE}
+        {:width => width, :height => height, :content_type => CONTENT_TYPE, :dimensions => [width, height], :file_size => size(stream)}
       end
 
       def self.detected?(stream)
@@ -58,6 +58,10 @@ class ImageSpec
             stream.readframe
           end
         end
+      end
+
+      def self.size(stream)
+        stream.size
       end
 
     end

--- a/lib/parser/png.rb
+++ b/lib/parser/png.rb
@@ -7,7 +7,7 @@ class ImageSpec
 
       def self.attributes(stream)
         width, height = dimensions(stream)
-        {:width => width, :height => height, :content_type => CONTENT_TYPE}
+        {:width => width, :height => height, :content_type => CONTENT_TYPE, :dimensions => [width, height], :file_size => size(stream)}
       end
 
       def self.detected?(stream)
@@ -18,6 +18,10 @@ class ImageSpec
       def self.dimensions(stream)
         stream.seek(0x10)
         stream.read(8).unpack('NN')
+      end
+
+      def self.size(stream)
+        stream.size
       end
 
     end

--- a/lib/parser/swf.rb
+++ b/lib/parser/swf.rb
@@ -9,7 +9,7 @@ class ImageSpec
 
       def self.attributes(stream)
         width, height = dimensions(stream)
-        {:width => width, :height => height, :content_type => CONTENT_TYPE}
+        {:width => width, :height => height, :content_type => CONTENT_TYPE, :dimensions => [width, height], :file_size => size(stream)}
       end
 
       def self.detected?(stream)
@@ -67,6 +67,10 @@ class ImageSpec
 
         # If you can't figure this one out, you probably shouldn't have read this far
         return [width, height]
+      end
+
+      def self.size(stream)
+        stream.size
       end
 
     end

--- a/test/image_spec_test.rb
+++ b/test/image_spec_test.rb
@@ -11,23 +11,23 @@ class ImageSpecTest < Test::Unit::TestCase
   end
 
   def assert_spec(values, spec)
-    assert_equal values, [spec.width, spec.height, spec.content_type]
+    assert_equal values, [spec.width, spec.height, spec.content_type, spec.dimensions, spec.file_size]
   end
 
   def test_identifying_jpeg
-    assert_spec [728, 90, "image/jpeg"], ImageSpec.new(fixture('leaderboard.jpg'))
+    assert_spec [728, 90, "image/jpeg", [728, 90], 2339], ImageSpec.new(fixture('leaderboard.jpg'))
   end
 
   def test_identifying_gif
-    assert_spec [120, 600, "image/gif"], ImageSpec.new(fixture('skyscraper.gif'))
+    assert_spec [120, 600, "image/gif", [120, 600], 10431], ImageSpec.new(fixture('skyscraper.gif'))
   end
 
   def test_identifying_png
-    assert_spec [120, 600, "image/png"], ImageSpec.new(fixture('skyscraper.png'))
+    assert_spec [120, 600, "image/png", [120, 600], 6745], ImageSpec.new(fixture('skyscraper.png'))
   end
 
   def test_identifying_swf
-    assert_spec [728, 90, "application/x-shockwave-flash"], ImageSpec.new(fixture('leaderboard.swf'))
+    assert_spec [728, 90, "application/x-shockwave-flash", [728, 90], 20247], ImageSpec.new(fixture('leaderboard.swf'))
   end
 
   def test_corrupted_files


### PR DESCRIPTION
The parser now adds the fields `file_size` and `dimensions`. Whereas `file_size` simply holds the size of the supplied file and `dimensions` wrap the width height attributes in an array.
