### PR TITLE
Flash detection broke under some circumstances

### DIFF
--- a/lib/parser/swf.rb
+++ b/lib/parser/swf.rb
@@ -21,7 +21,7 @@ class ImageSpec
         # Read the entire stream into memory because the
         # dimensions aren't stored in a standard location
         stream.rewind
-        contents = stream.read
+        contents = stream.read.force_encoding("ASCII-8BIT")
 
         # Our 'signature' is the first 3 bytes
         # Either FWS or CWS.  CWS indicates compression


### PR DESCRIPTION
Forcing the encoding of the input to ASCII-8BIT solved it, unsure why this happend tough the magic comment already points to ASCII-8BIT. Every other parser was worker well.
