### PR TITLE
Nbits fix

### DIFF
--- a/lib/parser/swf.rb
+++ b/lib/parser/swf.rb
@@ -41,7 +41,7 @@ class ImageSpec
         end
 
         # Determine the nbits of our dimensions rectangle
-        nbits =contents.unpack('c'*contents.length)[8] >> 3
+        nbits = contents.unpack('C'*contents.length)[8] >> 3
 
         # Determine how many bits long this entire RECT structure is
         rectbits = 5 + nbits * 4    # 5 bits for nbits, as well as nbits * number of fields (4)


### PR DESCRIPTION
Add nbits reading fix: read as unsigned int instead of signed int. Copied from [this commit](https://github.com/andersonbrandon/ruby-imagespec/commit/d1747691b5cc2d61dae1fd81b38294b182eaabaf).
